### PR TITLE
(vitineth/permission): adding permission support via keycloak

### DIFF
--- a/src/utilities/APIGen.ts
+++ b/src/utilities/APIGen.ts
@@ -432,6 +432,7 @@ export const EventResponseZod = EventCreationZod.omit({ venue: true, ents: true,
     venues: z.array(VenueResponseZod),
     ents: EntsStateResponseZod.optional(),
     state: StateResponseZod.optional(),
+    author: UserZod,
     id: z.string(),
 });
 export type EventResponse = z.infer<typeof EventResponseZod>;


### PR DESCRIPTION
This integrates role based permissions as defined in keycloak. Four roles are defined
* admin
* extended
* ops
* ents

Admin should have permission to do everything on the system. Ops are allowed to manage venues, states, etc. Ents can view everything and are allowed to access the equipment regions. Extended is reserved for users between normal and ents where they can see all without editing anything. This will need to be updated later if required. 