### PR TITLE
(vitineth/feature/workflow): adding ops planning workflow with additional upgrades

### DIFF
--- a/src/components/atoms/calendar/Calendar.module.scss
+++ b/src/components/atoms/calendar/Calendar.module.scss
@@ -1,0 +1,157 @@
+.calendar {
+  --lines: gainsboro;
+  --text: #6a6a6a;
+
+  box-sizing: border-box;
+  width: 100%;
+  // TODO: When this is 100% the calendar is *slightly* taller than the page, when 1920x1080
+  height: 96%;
+  display: grid;
+  grid-template-columns: 4pc repeat(5, 1fr);
+  grid-template-rows: 3pc 1fr;
+  grid-column-gap: 0px;
+  grid-row-gap: 0px;
+  position: relative;
+
+  .buttons{
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: flex;
+    flex-direction: row;
+
+    .button{
+      width: 3pc;
+      height: 3pc;
+      border-radius: 100%;
+      margin-left: 10px;
+      border: 1px solid gainsboro;
+      box-shadow: #444444 2px 2px 7px -3px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #afafaf;
+      cursor: pointer;
+
+      &:hover{
+        background: #f5f5f5;
+      }
+
+      >svg{
+        font-size: 20px;
+        //width: 50px !important;
+      }
+    }
+  }
+
+  .content {
+    grid-area: 2/1/3/7;
+    height: 100%;
+    position: relative;
+    //background: red;
+
+    display: grid;
+    grid-template-columns: 4pc repeat(5, 1fr);
+    grid-template-rows: repeat(24, 1fr);
+    grid-column-gap: 0px;
+    grid-row-gap: 0px;
+
+    .event {
+      text-decoration: none;
+      box-sizing: border-box;
+      color: white;
+      border-radius: 5px;
+      position: absolute;
+      border: 1px solid white;
+      background: #cf6a87;
+      line-height: 10px;
+      padding: 3px;
+      z-index: 1;
+      min-height: 21px;
+
+      strong{
+        padding-top: 10px;
+        line-height:1em;
+        font-size: 0.76rem;
+      }
+
+      span {
+        font-size: 0.6em;
+      }
+    }
+
+    .vertical {
+      //background: cyan;
+      border-right: 1px solid var(--lines);
+
+      &::after {
+        height: calc(100% / 24);
+        display: block;
+        content: " ";
+        bottom: calc(-1 * (100%/24));
+        position: absolute;
+        width: calc((100% - 4pc)/5);
+        box-sizing: border-box;
+        z-index: 0;
+        //left: calc(4pc + 1 * ((100% - 4pc) / 5));
+        border-bottom: 1px solid gainsboro;
+        border-right: 1px solid gainsboro;
+      }
+    }
+
+    .long {
+      border-bottom: 1px solid var(--lines);
+    }
+
+    .short {
+      position: relative;
+
+      span {
+        position: absolute;
+        bottom: -7px;
+        right: 10px;
+        color: var(--text);
+        font-size: 0.6em;
+      }
+    }
+  }
+
+  .top {
+    //border-right: 1px solid var(--lines);
+
+    > div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-direction: column;
+      height: 100%;
+      margin-top: 15px;
+      color: var(--text);
+
+      .number {
+        font-size: 1.6em;
+        font-weight: bold;
+      }
+    }
+  }
+
+  .topOne {
+    grid-area: 1 / 2 / 2 / 3;
+  }
+
+  .topTwo {
+    grid-area: 1 / 3 / 2 / 4;
+  }
+
+  .topThree {
+    grid-area: 1 / 4 / 2 / 5;
+  }
+
+  .topFour {
+    grid-area: 1 / 5 / 2 / 6;
+  }
+
+  .topFive {
+    grid-area: 1 / 6 / 2 / 7;
+  }
+}

--- a/src/components/atoms/calendar/Calendar.module.scss
+++ b/src/components/atoms/calendar/Calendar.module.scss
@@ -7,7 +7,7 @@
   // TODO: When this is 100% the calendar is *slightly* taller than the page, when 1920x1080
   height: 96%;
   display: grid;
-  grid-template-columns: 4pc repeat(5, 1fr);
+  grid-template-columns: 4pc repeat(7, 1fr);
   grid-template-rows: 3pc 1fr;
   grid-column-gap: 0px;
   grid-row-gap: 0px;
@@ -90,10 +90,8 @@
         content: " ";
         bottom: calc(-1 * (100%/24));
         position: absolute;
-        width: calc((100% - 4pc)/5);
         box-sizing: border-box;
         z-index: 0;
-        //left: calc(4pc + 1 * ((100% - 4pc) / 5));
         border-bottom: 1px solid gainsboro;
         border-right: 1px solid gainsboro;
       }
@@ -131,27 +129,15 @@
       .number {
         font-size: 1.6em;
         font-weight: bold;
+
+        >span{
+          position: absolute;
+          font-size: 0.5em;
+          margin-top: 11px;
+          margin-left: -17px;
+        }
       }
     }
   }
 
-  .topOne {
-    grid-area: 1 / 2 / 2 / 3;
-  }
-
-  .topTwo {
-    grid-area: 1 / 3 / 2 / 4;
-  }
-
-  .topThree {
-    grid-area: 1 / 4 / 2 / 5;
-  }
-
-  .topFour {
-    grid-area: 1 / 5 / 2 / 6;
-  }
-
-  .topFive {
-    grid-area: 1 / 6 / 2 / 7;
-  }
 }

--- a/src/components/atoms/calendar/Calendar.tsx
+++ b/src/components/atoms/calendar/Calendar.tsx
@@ -1,0 +1,245 @@
+import React, {CSSProperties} from "react";
+import styles from "./Calendar.module.scss";
+import {classes} from "../../../utilities/UIUtilities";
+import moment, {Moment} from "moment";
+import {EventResponse} from "../../../utilities/APIGen";
+import {EVENT_VIEW} from "../../../utilities/Routes";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faArrowLeft, faArrowRight} from "@fortawesome/free-solid-svg-icons";
+
+type CalendarProps = {
+    startDate?: Date,
+    days: number,
+    events: EventResponse[],
+}
+
+type CalendarState = {
+    startDate: Moment,
+    events: PositionedEvent[],
+}
+
+function hourToTop(hour: number, hours: number = 24) {
+    return `calc(${hour + 1} * (100% / ${hours}))`
+}
+
+function dayToLeft(day: number, offset: number = 0, split: number = 0, days: number = 5) {
+    if (offset !== 0) {
+        const blockWidth = `${offset} * ((100% - 4pc) / ${days * (1 / split)})`;
+        return `calc(4pc + (${day} * ((100% - 4pc) / ${days})) + ${blockWidth})`;
+    }
+    return `calc(4pc + (${day} * ((100% - 4pc) / ${days})))`
+}
+
+function hoursToHeight(duration: number, hours: number = 24) {
+    return `calc(${duration} * (100% / ${hours}))`
+}
+
+function blockWidth(scale: number = 1, amount: number = 1, days: number = 5) {
+    return `calc(((100% - 4pc) / ${days * (1 / scale)}) * ${amount})`;
+}
+
+const EventBlock: React.FunctionComponent<{ event: PositionedEvent, startOfCalendar: Moment }> = (props) => {
+    const start = moment.unix(props.event.event.start);
+    const end = moment.unix(props.event.event.end);
+    const dayOffset = start.diff(props.startOfCalendar, 'days');
+    const hourOffset = start.hour() + (start.minute() / 60);
+    const duration = end.diff(start, 'minutes') / 60;
+
+    let internals: React.ReactNode[] = [];
+    if (!props.event.parent) {
+        internals = [<br/>,
+            <span>{moment.unix(props.event.event.start).format('h:mm')} - {moment.unix(props.event.event.end).format('h:mm A')}</span>,
+            <br/>,
+            <span>{props.event.event.venues.map((e) => e.name).join(', ')}</span>];
+    }
+
+    const colourOverride: CSSProperties = {};
+    if (props.event.event.color) {
+        colourOverride.backgroundColor = props.event.event.color;
+    }
+
+    return (<a
+        href={EVENT_VIEW.make(props.event.parent ?? props.event.event.id)}
+        className={styles.event}
+        style={{
+            left: dayToLeft(dayOffset, props.event.offset, props.event.split),
+            top: hourToTop(hourOffset),
+            height: hoursToHeight(duration),
+            width: blockWidth(props.event.split, props.event.width),
+            ...colourOverride,
+        }}
+    >
+        <strong>{props.event.event.name}</strong>
+        {internals}
+    </a>)
+};
+
+type PositionedEvent = {
+    event: EventResponse,
+    startMoment: Moment,
+    endMoment: Moment,
+    offset: number,
+    split: number,
+    width: number,
+    parent?: string,
+}
+
+export class CalendarRedo extends React.Component<CalendarProps, CalendarState> {
+
+    private _cachedLayout: React.ReactNode[] | undefined;
+
+    constructor(props: CalendarProps, context: any) {
+        super(props, context);
+        this.state = {
+            events: CalendarRedo.position(props.events),
+            startDate: moment.unix((props.startDate ?? moment().startOf('week').toDate()).getTime() / 1000).hour(0).minute(0).seconds(0).millisecond(0),
+        };
+    }
+
+    private static position(events: EventResponse[]): PositionedEvent[] {
+        // Go day by day
+        const grouped: Record<number, PositionedEvent[]> = {};
+        for (const e of events) {
+            const em: PositionedEvent = {
+                event: e,
+                startMoment: moment.unix(e.start),
+                endMoment: moment.unix(e.end),
+                offset: 0,
+                split: 0.1,
+                width: 10,
+            };
+
+            if (em.startMoment.day() !== em.endMoment.day()) {
+                const overlap = em.endMoment.diff(em.endMoment.clone().hours(0).minute(0).seconds(0).millisecond(0));
+                if (overlap !== 0) {
+                    console.log('multi day', em, overlap);
+                    const original = em.endMoment.clone();
+                    em.endMoment = em.startMoment.clone().hours(23).minute(59).seconds(59).millisecond(9999);
+                    em.event.end = em.endMoment.unix();
+
+                    const newStart = em.endMoment.clone().hours(0).minute(0).seconds(0).millisecond(0);
+
+                    const n: PositionedEvent = {
+                        event: {
+                            ...e,
+                            start: newStart.unix(),
+                            end: original.unix(),
+                            name: '*' + e.name,
+                        },
+                        width: 10,
+                        split: 0.1,
+                        offset: 0,
+                        parent: e.id,
+                        startMoment: newStart,
+                        endMoment: original,
+                    };
+
+                    if (grouped[n.startMoment.day()]) grouped[n.startMoment.day()].push(n);
+                    else grouped[n.startMoment.day()] = [n];
+                }
+            }
+
+            if (grouped[em.startMoment.day()]) grouped[em.startMoment.day()].push(em);
+            else grouped[em.startMoment.day()] = [em];
+        }
+
+        const sets = Object
+            .values(grouped)
+            .map((e) =>
+                e.sort((a, b) => a.event.start - b.event.start),
+            );
+
+        for (const set of sets) {
+            for (let i = 1; i < set.length; i++) {
+                const prev = set[i - 1];
+                const now = set[i];
+
+                if (now.parent) continue;
+
+                if (now.event.start > prev.event.start && now.event.start <= prev.event.end) {
+                    console.log(now.event.start, prev.event.start, now.event.start - prev.event.start);
+                    if (now.event.start - prev.event.start <= 30 * 60) {
+                        prev.width *= (2 / 3);
+                        now.width = prev.width;
+                        now.offset = prev.offset + 3;
+                    } else {
+                        now.offset = prev.offset + 1;
+                        now.width = prev.width - 1;
+                    }
+                }
+
+                if (now.event.start === prev.event.start) {
+                    prev.width /= 2;
+                    now.width = prev.width;
+                    now.offset = prev.offset + prev.width;
+                }
+            }
+        }
+
+        const elements = sets.flat();
+
+        for (const event of elements) {
+            if (event.parent) {
+                event.split = elements.find((e) => e.event.id === event.parent)?.split ?? 0.1;
+                event.width = elements.find((e) => e.event.id === event.parent)?.width ?? 10;
+                event.offset = elements.find((e) => e.event.id === event.parent)?.offset ?? 0;
+            }
+        }
+
+        return elements;
+    }
+
+    render() {
+        if (this._cachedLayout === undefined) {
+            this._cachedLayout = [
+                ...Array(24).fill(0).map((_, i) => [
+                    <div className={styles.short} style={{gridArea: `${i + 1}/1/${i + 2}/2`}}
+                         data-wtf={`${i + 1}/1/${i + 2}/2`}>
+                            <span>
+                            {i % 12 === 0 ? 12 : i % 12} {i > 12 ? 'PM' : 'AM'}
+                                </span>
+                    </div>,
+                    <div className={styles.long} style={{gridArea: `${i + 1}/2/${i + 2}/7`}}/>
+                ]).flat(),
+                ...Array(this.props.days).fill(0).map((_, i) => (
+                    <div className={styles.vertical} style={{gridArea: `1/${i + 2}/25/${i + 3}`}}/>
+                ))
+            ];
+        }
+        return (
+            <div className={styles.calendar}>
+                <div className={styles.buttons}>
+                    <div className={styles.button} onClick={() => this.setState((s) => ({
+                        ...s,
+                        startDate: s.startDate.clone().subtract(7, 'days')
+                    }))}>
+                        <FontAwesomeIcon icon={faArrowLeft}/>
+                    </div>
+                    <div className={styles.button}
+                         onClick={() => this.setState((s) => ({...s, startDate: s.startDate.clone().add(7, 'days')}))}>
+                        <FontAwesomeIcon icon={faArrowRight}/>
+                    </div>
+                </div>
+                {Array(this.props.days).fill(0).map((_, i) => (
+                    <div className={classes(styles.topOne, styles.top)} style={{gridArea: `1/${i + 2}/2/${i + 3}`}}>
+                        <div>
+                            <div className={styles.number}>{this.state.startDate.clone().add(i, 'day').date()}</div>
+                            <div
+                                className={styles.day}>{this.state.startDate.clone().add(i, 'day').format('MMMM')}</div>
+                        </div>
+                    </div>
+                ))}
+
+                <div className={styles.content}>
+                    {this.state.events.map((e) =>
+                        <EventBlock
+                            event={e}
+                            startOfCalendar={this.state.startDate}
+                        />)}
+                    {this._cachedLayout}
+                </div>
+            </div>
+        );
+    }
+
+}

--- a/src/components/atoms/comment-box/CommentBox.tsx
+++ b/src/components/atoms/comment-box/CommentBox.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { faComment } from '@fortawesome/free-solid-svg-icons';
+import {Link} from 'react-router-dom';
+import {faComment} from '@fortawesome/free-solid-svg-icons';
 
-import { TextField } from '../text-field/TextField';
-import { Button } from '../button/Button';
+import {TextField} from '../text-field/TextField';
+import {Button} from '../button/Button';
 
 import '../comment/Comment.scss';
-import { KeyValueOption, Select } from '../select/Select';
-import { GlobalContext } from '../../../context/GlobalContext';
-import { TopicResponse } from '../../../utilities/APIGen';
+import {KeyValueOption, Select} from '../select/Select';
+import {GlobalContext} from '../../../context/GlobalContext';
+import {TopicResponse} from '../../../utilities/APIGen';
 
 export type CommentBoxPropsType = {
     /**
@@ -145,13 +145,16 @@ export class CommentBox extends React.Component<CommentBoxPropsType, CommentBoxS
                         {
                             this.context.user.value
                                 ? (
-                                    <Link className="poster" to={`/user/${this.context.user.value.username}`}>
+                                    <div className="poster">
+                                        {/*TODO: SEE https://app.asana.com/0/1199734926192621/1202299888223891/f*/}
+                                        {/*<Link className="poster" to={`/user/${this.context.user.value.username}`}>*/}
+                                        {/*</Link>*/}
                                         <div className="name">{this.context.user.value.name}</div>
                                         <div className="username">
                                             @
                                             {this.context.user.value.username}
                                         </div>
-                                    </Link>
+                                    </div>
                                 )
                                 : (
                                     <div className="poster">

--- a/src/components/atoms/comment-box/CommentBox.tsx
+++ b/src/components/atoms/comment-box/CommentBox.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {Link} from 'react-router-dom';
 import {faComment} from '@fortawesome/free-solid-svg-icons';
 
 import {TextField} from '../text-field/TextField';

--- a/src/components/atoms/comment/Comment.tsx
+++ b/src/components/atoms/comment/Comment.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {Link} from 'react-router-dom';
 import Markdown from 'markdown-to-jsx';
 import ReactTimeAgo from 'react-time-ago';
 import ReactTooltip from 'react-tooltip';

--- a/src/components/atoms/comment/Comment.tsx
+++ b/src/components/atoms/comment/Comment.tsx
@@ -66,13 +66,16 @@ export function Comment(props: CommentPropsType) {
             </div>
             <div className="right">
                 <div className="top">
-                    <Link className="poster" to={`/user/${props.comment.poster.username}`}>
+                    <div className="poster">
+                        {/*TODO: SEE https://app.asana.com/0/1199734926192621/1202299888223891/f*/}
+                        {/*<Link className="poster" to={`/user/${props.comment.poster.username}`}>*/}
+                        {/*</Link>*/}
                         <div className="name">{props.comment.poster.name}</div>
                         <div className="username">
                             @
                             {props.comment.poster.username}
                         </div>
-                    </Link>
+                    </div>
                     <div className="spacer"/>
                     <div className="time">
                         <ReactTimeAgo locale="en" date={props.comment.posted * 1000}/>

--- a/src/components/atoms/text-field/TextField.scss
+++ b/src/components/atoms/text-field/TextField.scss
@@ -6,7 +6,7 @@
     font-size: 14px;
     padding: 10px 10px 10px 5px;
     display: block;
-    border: none;
+    border: 1px solid #f6f6f6;
     border-bottom: 1px solid #757575;
     width: 100%;
     box-sizing: border-box;

--- a/src/components/atoms/venue-chip/VenueChip.module.scss
+++ b/src/components/atoms/venue-chip/VenueChip.module.scss
@@ -13,3 +13,21 @@
     font-size: 0.4em;
   }
 }
+
+.venueChip.removable {
+  display: inline-grid;
+
+  .top {
+    grid-area: 1/1/2/2;
+  }
+
+  .bottom {
+    grid-area: 2/1/3/2;
+  }
+
+  .icon {
+    grid-area: 1/2/3/3;
+    align-self: center;
+    margin-left: 10px;
+  }
+}

--- a/src/components/atoms/venue-chip/VenueChip.module.scss
+++ b/src/components/atoms/venue-chip/VenueChip.module.scss
@@ -1,0 +1,15 @@
+.venueChip {
+  display: inline-block;
+  padding: 5px 10px;
+  border-radius: 100px;
+  margin: 2px;
+
+  .top {
+    font-weight: bold;
+  }
+
+  .bottom {
+    margin-top: 1px;
+    font-size: 0.4em;
+  }
+}

--- a/src/components/atoms/venue-chip/VenueChip.tsx
+++ b/src/components/atoms/venue-chip/VenueChip.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import {VenueResponse} from "../../../utilities/APIGen";
+import styles from './VenueChip.module.scss';
+import {ColorUtilities} from "../../../utilities/ColorUtilities";
+import {Link} from "react-router-dom";
+
+/**
+ * Produces a venue chip with the name, capacity and background of the provided venue. If link is true then it will
+ * return as a link to the venue page, if not it is returned as a div.
+ * @param venue the venue which should be represented
+ * @param link if the element should be represented as a link or a div
+ * @constructor
+ */
+const VenueChip: React.FunctionComponent<{ venue: VenueResponse, link?: boolean }> = ({venue, link}) => {
+    const internal = [
+        (<div className={styles.top}>{venue.name}</div>),
+        (<div className={styles.bottom}>Capacity {venue.capacity}</div>),
+    ];
+
+    const style = {
+        backgroundColor: venue.color ?? '#000000',
+        color: ColorUtilities.determineForegroundColor(venue.color ?? '#000000')
+    };
+
+    if (link) {
+        return (<Link to={`/venues/${venue.id}`} className={styles.venueChip} style={style}>
+            {internal}
+        </Link>)
+    }
+
+    return (
+        <div className={styles.venueChip} style={style}>
+            {internal}
+        </div>
+    );
+}
+
+export default VenueChip;

--- a/src/components/atoms/venue-chip/VenueChip.tsx
+++ b/src/components/atoms/venue-chip/VenueChip.tsx
@@ -1,20 +1,47 @@
-import React from "react";
+import React, {CSSProperties} from "react";
 import {VenueResponse} from "../../../utilities/APIGen";
 import styles from './VenueChip.module.scss';
 import {ColorUtilities} from "../../../utilities/ColorUtilities";
 import {Link} from "react-router-dom";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faTimesCircle} from "@fortawesome/free-solid-svg-icons";
+
+/**
+ * The properties for a venue chip to render as a chip
+ */
+type VenueChipType = {
+    /**
+     * The venue which should be rendered in the chip
+     */
+    venue: VenueResponse,
+    /**
+     * If the element should be rendered as a link to the venue page
+     */
+    link?: boolean,
+    /**
+     * Any additional styles to apply to the outermost element of the container
+     */
+    style?: CSSProperties,
+    /**
+     * Any additional class names to apply to the outermost element of the container
+     */
+    className?: string,
+};
 
 /**
  * Produces a venue chip with the name, capacity and background of the provided venue. If link is true then it will
  * return as a link to the venue page, if not it is returned as a div.
  * @param venue the venue which should be represented
  * @param link if the element should be represented as a link or a div
+ * @param children the children of this element that should be rendered inside the element
+ * @param rest the rest of the parameters from {@link VenueChipType}
  * @constructor
  */
-const VenueChip: React.FunctionComponent<{ venue: VenueResponse, link?: boolean }> = ({venue, link}) => {
+const VenueChip: React.FunctionComponent<VenueChipType> = ({venue, link, children, ...rest}) => {
     const internal = [
         (<div className={styles.top}>{venue.name}</div>),
         (<div className={styles.bottom}>Capacity {venue.capacity}</div>),
+        children,
     ];
 
     const style = {
@@ -22,17 +49,46 @@ const VenueChip: React.FunctionComponent<{ venue: VenueResponse, link?: boolean 
         color: ColorUtilities.determineForegroundColor(venue.color ?? '#000000')
     };
 
+    const classes = [styles.venueChip, rest.className].filter((e) => e !== undefined).join(' ');
+
     if (link) {
-        return (<Link to={`/venues/${venue.id}`} className={styles.venueChip} style={style}>
+        return (<Link
+            to={`/venues/${venue.id}`}
+            className={classes}
+            style={style}
+        >
             {internal}
         </Link>)
     }
 
     return (
-        <div className={styles.venueChip} style={style}>
+        <div className={classes} style={{...style, ...rest.style}}>
             {internal}
         </div>
     );
 }
+
+/**
+ * The props for a venue chip extended with the onRemove handler for when the delete icon is pressed
+ */
+type RemovableVenueChipType = VenueChipType & {
+    /**
+     * To be called when the remove icon is clicked on the venue chip
+     */
+    onRemove?: () => void,
+};
+
+/**
+ * Creates a {@link VenueChip} but with support for a cross icon on the right which when clicked will call the
+ * {@link RemovableVenueChipType#onRemove} value if provided. The aesthetics are the same as the regular chip, just with
+ * a cross.
+ * @param props the properties of this venue chip
+ * @constructor
+ */
+export const RemovableVenueChip: React.FunctionComponent<RemovableVenueChipType> = (props) => (
+    <VenueChip venue={props.venue} link={props.link} className={styles.removable}>
+        <FontAwesomeIcon icon={faTimesCircle} className={styles.icon} onClick={() => props.onRemove?.()}/>
+    </VenueChip>
+)
 
 export default VenueChip;

--- a/src/components/components/editable-property/EditableProperty.tsx
+++ b/src/components/components/editable-property/EditableProperty.tsx
@@ -1,4 +1,4 @@
-import React, {createRef, Ref, RefObject} from 'react';
+import React, {createRef, RefObject} from 'react';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {faEdit} from '@fortawesome/free-solid-svg-icons';
 import DatePicker from 'react-flatpickr';
@@ -13,7 +13,6 @@ import {OptionType} from '../../atoms/icon-picker/EntrySelector';
 import {failEarlyStateSet} from '../../../utilities/AccessUtilities';
 import {IconSelector} from '../../atoms/icon-picker/IconPicker';
 import './EditableProperty.scss';
-import {create} from "domain";
 
 export type CheckboxType = {
     type: 'checkbox',

--- a/src/components/components/editable-property/EditableProperty.tsx
+++ b/src/components/components/editable-property/EditableProperty.tsx
@@ -1,18 +1,25 @@
-import React from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEdit } from '@fortawesome/free-solid-svg-icons';
+import React, {createRef, Ref, RefObject} from 'react';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {faEdit} from '@fortawesome/free-solid-svg-icons';
 import DatePicker from 'react-flatpickr';
-import { TwitterPicker } from 'react-color';
-import { KeyValueOption, Select } from '../../atoms/select/Select';
-import { Button } from '../../atoms/button/Button';
-import { Theme } from '../../../theme/Theme';
+import {TwitterPicker} from 'react-color';
+import {KeyValueOption, Select} from '../../atoms/select/Select';
+import {Button} from '../../atoms/button/Button';
+import {Theme} from '../../../theme/Theme';
 
 import InputUtilities from '../../../utilities/InputUtilities';
-import { TextField, TextFieldPropsType } from '../../atoms/text-field/TextField';
-import { OptionType } from '../../atoms/icon-picker/EntrySelector';
-import { failEarlyStateSet } from '../../../utilities/AccessUtilities';
-import { IconSelector } from '../../atoms/icon-picker/IconPicker';
+import {TextField, TextFieldPropsType} from '../../atoms/text-field/TextField';
+import {OptionType} from '../../atoms/icon-picker/EntrySelector';
+import {failEarlyStateSet} from '../../../utilities/AccessUtilities';
+import {IconSelector} from '../../atoms/icon-picker/IconPicker';
 import './EditableProperty.scss';
+import {create} from "domain";
+
+export type CheckboxType = {
+    type: 'checkbox',
+    onChange?: (value: boolean) => void,
+    value: boolean,
+}
 
 export type IconType = {
     type: 'icon',
@@ -54,7 +61,7 @@ export type EditablePropertyPropsType = {
      * An editable property must contain one or more children which are rendered by default when not in edit mode
      */
     children: React.ReactNode | React.ReactNode[],
-    config: SelectType | DateType | TextType | ColorType | IconType,
+    config: SelectType | DateType | TextType | ColorType | IconType | CheckboxType,
 }
 
 export type EditablePropertyStateType = {
@@ -73,9 +80,12 @@ export type EditablePropertyStateType = {
 export class EditableProperty extends React.Component<EditablePropertyPropsType, EditablePropertyStateType> {
 
     static displayName = 'EditableProperty';
+    private inputRef: RefObject<HTMLInputElement>;
 
     constructor(props: Readonly<EditablePropertyPropsType>) {
         super(props);
+
+        this.inputRef = createRef();
 
         this.state = {
             editMode: false,
@@ -132,6 +142,7 @@ export class EditableProperty extends React.Component<EditablePropertyPropsType,
             input: value,
         }));
     }
+
     /**
      * If the selected property has been updated, it will disable editing and then call the onChange listener if one
      * has been provided
@@ -163,6 +174,9 @@ export class EditableProperty extends React.Component<EditablePropertyPropsType,
         if (this.props.config.type === 'color' && this.state.selectProperty) {
             if (this.props.config.onChange) this.props.config.onChange(this.state.selectProperty as string);
         }
+        if (this.props.config.type === 'checkbox' && this.state.input !== undefined) {
+            if (this.props.config.onChange) this.props.config.onChange(this.state.input as boolean);
+        }
     }
 
     private renderIcon = () => (
@@ -180,6 +194,24 @@ export class EditableProperty extends React.Component<EditablePropertyPropsType,
             }}
             color={this.state.selectProperty as (string | undefined)}
         />
+    );
+
+    private renderCheckbox = (box: CheckboxType) => (
+        <>
+        <input type="checkbox"
+               id={`editable-checkbox-${btoa(this.props.name)}`}
+               checked={this.state.input ?? box.value}
+               ref={this.inputRef}
+               onChange={() => {
+                   console.log(this.inputRef, this.inputRef.current?.checked ?? false);
+                   this.setState((oldState) => ({
+                       ...oldState,
+                       input: this.inputRef.current?.checked ?? false
+                   }));
+               }}
+        />
+            <label htmlFor={`editable-checkbox-${btoa(this.props.name)}`}>{this.props.name}</label>
+        </>
     );
 
     private renderSelect = (select: SelectType) => {
@@ -246,6 +278,8 @@ export class EditableProperty extends React.Component<EditablePropertyPropsType,
                 );
             case 'icon':
                 return (this.renderIcon());
+            case 'checkbox':
+                return (this.renderCheckbox(this.props.config))
             default:
                 return undefined;
         }
@@ -292,7 +326,7 @@ export class EditableProperty extends React.Component<EditablePropertyPropsType,
                     onKeyPress={InputUtilities.higherOrderPress(InputUtilities.SPACE, this.enableEditing, this)}
                     onClick={this.enableEditing}
                 >
-                    <FontAwesomeIcon icon={faEdit} />
+                    <FontAwesomeIcon icon={faEdit}/>
                     (Edit...)
                 </span>
             </div>

--- a/src/components/components/event-table/EventTable.tsx
+++ b/src/components/components/event-table/EventTable.tsx
@@ -203,7 +203,7 @@ export class EventTable extends React.Component<EventTablePropsType, EventTableS
 
                 <LinkedTD to={`/events/${event.id}`}>{event.name}</LinkedTD>
                 <LinkedTD to={`/events/${event.id}`}>
-                    {event.venues.map((e) => (<VenueChip venue={e}/>))}
+                    {event.venues.map((e) => (<VenueChip venue={e} key={e.id}/>))}
                 </LinkedTD>
                 <LinkedTD to={`/events/${event.id}`}>
                     {moment.unix(event.start).format(' dddd Do MMMM (YYYY), HH:mm ')}

--- a/src/components/components/event-table/EventTable.tsx
+++ b/src/components/components/event-table/EventTable.tsx
@@ -20,6 +20,7 @@ import { IconName } from '@fortawesome/free-solid-svg-icons';
 import { ColorUtilities } from "../../../utilities/ColorUtilities";
 import { KeyValueOption } from "../../atoms/select/Select";
 import { API, EntsStateResponse, EventResponse, StateResponse, VenueResponse } from "../../../utilities/APIGen";
+import VenueChip from "../../atoms/venue-chip/VenueChip";
 
 export type EventTablePropsType = {
     /**
@@ -201,7 +202,9 @@ export class EventTable extends React.Component<EventTablePropsType, EventTableS
                 </LinkedTD>
 
                 <LinkedTD to={`/events/${event.id}`}>{event.name}</LinkedTD>
-                <LinkedTD to={`/events/${event.id}`}>{event.venues.map((e) => e.name).join(', ')}</LinkedTD>
+                <LinkedTD to={`/events/${event.id}`}>
+                    {event.venues.map((e) => (<VenueChip venue={e}/>))}
+                </LinkedTD>
                 <LinkedTD to={`/events/${event.id}`}>
                     {moment.unix(event.start).format(' dddd Do MMMM (YYYY), HH:mm ')}
                     &#8594;

--- a/src/components/components/sidebar/Sidebar.tsx
+++ b/src/components/components/sidebar/Sidebar.tsx
@@ -167,7 +167,7 @@ export default function Sidebar() {
                 </NavLink>
             </div>
 
-            <NavLink to="/ops-planning" exact className={classes.navigationLink} onClick={navLinkClick} activeClassName={classes.active}>
+            <NavLink to="/workflow/ops" exact className={classes.navigationLink} onClick={navLinkClick} activeClassName={classes.active}>
                 <div className={classes.icon}>
                     <MdiSendOutline/>
                 </div>

--- a/src/components/components/tab-pane/TabPane.scss
+++ b/src/components/components/tab-pane/TabPane.scss
@@ -22,6 +22,7 @@
 
   .bodies {
     border-top: 1px solid gainsboro;
+    height: 100%;
 
     .body {
       display: none;

--- a/src/components/components/tab-pane/TabPane.tsx
+++ b/src/components/components/tab-pane/TabPane.tsx
@@ -200,7 +200,7 @@ export class TabPane extends React.Component<TabPanePropsType, TabPaneStateType>
         }
 
         return (
-            <div className="tabbed-pane">
+            <div className="tabbed-pane" style={this.props.style}>
                 <div className="tabs">
                     {tabs}
                 </div>

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -49,7 +49,7 @@ const config = ((p) => {
         default:
             return development;
     }
-})((process.env.REACT_APP_STAGE || '').toLowerCase());
+})((typeof(process) === 'undefined' ? '' : (process.env.REACT_APP_STAGE || '')).toLowerCase());
 
 /**
  * The final configuration merging the default values with the results of {@link config} as overrides on top

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,7 @@ import {ListFile} from './pages/file/list/ListFile';
 import {ViewFile} from './pages/file/view/ViewFile';
 import Axios from "axios";
 import Sidebar from "./components/components/sidebar/Sidebar";
+import {EVENT_VIEW} from "./utilities/Routes";
 
 // Register EN locale for time ago components
 JavascriptTimeAgo.addLocale(en);
@@ -221,122 +222,6 @@ class RootSite extends React.Component<{}, RootSiteState & ReadableContextType> 
                                     processNotifications(this.state.notifications, this.state.animationStates)
                                 }
                             />
-                            {/*<div className="sidebar-real">*/}
-                            {/*    <img*/}
-                            {/*        src="/ents-crew-white.png"*/}
-                            {/*        className="header-image"*/}
-                            {/*        alt="UEMS Logo:*/}
-                            {/*        The text UEMS in a bold geometric font surrounded by a white outlined rectangle."*/}
-                            {/*    />*/}
-                            {/*    <div className="sidebar-content">*/}
-                            {/*        <NavLink to="/" exact className="entry">*/}
-                            {/*            <FontAwesomeIcon icon={faColumns} />*/}
-                            {/*            <span>Dashboard</span>*/}
-                            {/*        </NavLink>*/}
-
-                            {/*        /!* EVENTS *!/*/}
-                            {/*        <NavLink to="/events" className="nav-link">*/}
-                            {/*            <div className="entry">*/}
-                            {/*                <FontAwesomeIcon icon={faCalendarTimes} />*/}
-                            {/*                <span>Events</span>*/}
-                            {/*            </div>*/}
-                            {/*        </NavLink>*/}
-                            {/*        <Switch>*/}
-                            {/*            <Route path="/events">*/}
-                            {/*                <div className="sub-entry">*/}
-                            {/*                    <NavLink to="/events/create" exact className="entry">*/}
-                            {/*                        <FontAwesomeIcon icon={faPlusCircle} />*/}
-                            {/*                        <span>Add</span>*/}
-                            {/*                    </NavLink>*/}
-                            {/*                </div>*/}
-                            {/*            </Route>*/}
-                            {/*        </Switch>*/}
-
-                            {/*        /!* VENUES *!/*/}
-                            {/*        <NavLink to="/venues" className="nav-link">*/}
-                            {/*            <div className="entry">*/}
-                            {/*                <FontAwesomeIcon icon={faBuilding} />*/}
-                            {/*                <span>Venues</span>*/}
-                            {/*            </div>*/}
-                            {/*        </NavLink>*/}
-                            {/*        <Switch>*/}
-                            {/*            <Route path="/venues">*/}
-                            {/*                <div className="sub-entry">*/}
-                            {/*                    <NavLink to="/venues/create" exact className="entry">*/}
-                            {/*                        <FontAwesomeIcon icon={faPlusCircle} />*/}
-                            {/*                        <span>Add</span>*/}
-                            {/*                    </NavLink>*/}
-                            {/*                </div>*/}
-                            {/*            </Route>*/}
-                            {/*        </Switch>*/}
-
-                            {/*        /!* FILES *!/*/}
-                            {/*        <NavLink to="/files" className="nav-link">*/}
-                            {/*            <div className="entry">*/}
-                            {/*                <FontAwesomeIcon icon={faFileContract} />*/}
-                            {/*                <span>Files</span>*/}
-                            {/*            </div>*/}
-                            {/*        </NavLink>*/}
-                            {/*        <Switch>*/}
-                            {/*            <Route path="/files">*/}
-                            {/*                <div className="sub-entry">*/}
-                            {/*                    <NavLink to="/files/create" exact className="entry">*/}
-                            {/*                        <FontAwesomeIcon icon={faCloudUploadAlt} />*/}
-                            {/*                        <span>Upload</span>*/}
-                            {/*                    </NavLink>*/}
-                            {/*                </div>*/}
-                            {/*            </Route>*/}
-                            {/*        </Switch>*/}
-
-                            {/*        /!* ENTS *!/*/}
-                            {/*        <NavLink to="/ents" className="nav-link">*/}
-                            {/*            <div className="entry">*/}
-                            {/*                <FontAwesomeIcon icon={faWrench} />*/}
-                            {/*                <span>Ents States</span>*/}
-                            {/*            </div>*/}
-                            {/*        </NavLink>*/}
-                            {/*        <Switch>*/}
-                            {/*            <Route path="/ents">*/}
-                            {/*                <div className="sub-entry">*/}
-                            {/*                    <NavLink to="/ents/create" exact className="entry">*/}
-                            {/*                        <FontAwesomeIcon icon={faPlusCircle} />*/}
-                            {/*                        <span>Add</span>*/}
-                            {/*                    </NavLink>*/}
-                            {/*                </div>*/}
-                            {/*            </Route>*/}
-                            {/*        </Switch>*/}
-
-                            {/*        /!* STATES *!/*/}
-                            {/*        <NavLink to="/states" className="nav-link">*/}
-                            {/*            <div className="entry">*/}
-                            {/*                <FontAwesomeIcon icon={faTags} />*/}
-                            {/*                <span>States</span>*/}
-                            {/*            </div>*/}
-                            {/*        </NavLink>*/}
-                            {/*        <Switch>*/}
-                            {/*            <Route path="/states">*/}
-                            {/*                <div className="sub-entry">*/}
-                            {/*                    <NavLink to="/states/create" exact className="entry">*/}
-                            {/*                        <FontAwesomeIcon icon={faPlusCircle} />*/}
-                            {/*                        <span>Add</span>*/}
-                            {/*                    </NavLink>*/}
-                            {/*                </div>*/}
-                            {/*            </Route>*/}
-                            {/*        </Switch>*/}
-
-                            {/*        /!* EQUIPMENT *!/*/}
-                            {/*        <NavLink to="/equipment" className="entry">*/}
-                            {/*            <FontAwesomeIcon icon={faBox} />*/}
-                            {/*            <span>Equipment</span>*/}
-                            {/*        </NavLink>*/}
-
-                            {/*        /!* OPS PLANNING *!/*/}
-                            {/*        <NavLink to="/ops-planning" className="entry">*/}
-                            {/*            <FontAwesomeIcon icon={faPaperPlane} />*/}
-                            {/*            <span>Ops Planning</span>*/}
-                            {/*        </NavLink>*/}
-                            {/*    </div>*/}
-                            {/*</div>*/}
                             <Sidebar/>
 
                             <div className="sidebar-spacer"/>
@@ -396,7 +281,7 @@ class RootSite extends React.Component<{}, RootSiteState & ReadableContextType> 
                                     <Route path="/events/create" exact>
                                         <CreateEvent isPage/>
                                     </Route>
-                                    <Route path="/events/:id" exact>
+                                    <Route path={EVENT_VIEW.string} exact>
                                         <Event/>
                                     </Route>
                                     <Route path="/events" exact>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,7 @@ import {ListEnt} from './pages/ents/list/ListEnt';
 import App from './pages/App';
 import {Events} from './pages/events/list/Events';
 import Event from './pages/events/view/Event';
+import {OpsPlanning} from './pages/workflows/ops-planning/OpsPlanning';
 
 import 'react-dates/initialize';
 import 'react-loader-spinner/dist/loader/css/react-spinner-loader.css';
@@ -400,6 +401,10 @@ class RootSite extends React.Component<{}, RootSiteState & ReadableContextType> 
                                     </Route>
                                     <Route path="/events" exact>
                                         <Events/>
+                                    </Route>
+
+                                    <Route path="/workflow/ops" exact>
+                                        <OpsPlanning/>
                                     </Route>
 
                                     <Route path="/" exact>

--- a/src/pages/events/list/Events.scss
+++ b/src/pages/events/list/Events.scss
@@ -1,5 +1,9 @@
 .events-page{
   padding: 20px;
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 
   .loading-pane{
     text-align: center;

--- a/src/pages/events/list/Events.tsx
+++ b/src/pages/events/list/Events.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 import Loader from 'react-loader-spinner';
-import { Calendar as CalendarElement } from '../../../components/components/calendar/Calendar';
-import { TabPane } from '../../../components/components/tab-pane/TabPane';
-import { EventTable } from '../../../components/components/event-table/EventTable';
-import { Theme } from '../../../theme/Theme';
+import {TabPane} from '../../../components/components/tab-pane/TabPane';
+import {EventTable} from '../../../components/components/event-table/EventTable';
+import {Theme} from '../../../theme/Theme';
 
 import './Events.scss';
-import { API, EventResponse } from '../../../utilities/APIGen';
+import {API, EventResponse} from '../../../utilities/APIGen';
 import {
     FallibleReactComponent,
     FallibleReactStateType
 } from "../../../components/components/error-screen/FallibleReactComponent";
-import { loadAPIData } from "../../../utilities/DataUtilities";
+import {loadAPIData} from "../../../utilities/DataUtilities";
 import {UIUtilities} from "../../../utilities/UIUtilities";
 import {withNotificationContext} from "../../../components/WithNotificationContext";
 import {NotificationPropsType} from "../../../context/NotificationContext";
+import {CalendarRedo} from "../../../components/atoms/calendar/Calendar";
 
 export type CalendarPropsType = {} & NotificationPropsType;
 
@@ -38,17 +38,6 @@ class EventsClass extends FallibleReactComponent<CalendarPropsType, CalendarStat
      * Load the events from the API endpoint and update the state with the properties or populate the error state
      */
     private loadComments() {
-        // API.events.get().then((events) => {
-        //     this.setState({
-        //         events: events.result,
-        //     });
-        // }).catch((err: Error) => {
-        //     this.setState((oldState) => ({
-        //         ...oldState,
-        //         error: `Failed to load the events due to ${err.message}`,
-        //     }));
-        // });
-
         loadAPIData<CalendarStateType>([{
             call: API.events.get,
             stateName: 'events',
@@ -82,12 +71,13 @@ class EventsClass extends FallibleReactComponent<CalendarPropsType, CalendarStat
                 className="events-page"
             >
                 <TabPane
+                    style={{flexGrow: 1}}
                     panes={[
                         {
                             key: 'calendar',
                             content: (
                                 this.state.events
-                                    ? <CalendarElement events={this.state.events} />
+                                    ? <CalendarRedo events={this.state.events} days={5}/>
                                     : loadOrError
                             ),
                             name: 'Calendar',
@@ -96,7 +86,7 @@ class EventsClass extends FallibleReactComponent<CalendarPropsType, CalendarStat
                             name: 'Table',
                             content: (
                                 this.state.events
-                                    ? <EventTable events={this.state.events} />
+                                    ? <EventTable events={this.state.events}/>
                                     : loadOrError
                             ),
                             key: 'table',
@@ -110,4 +100,5 @@ class EventsClass extends FallibleReactComponent<CalendarPropsType, CalendarStat
     }
 
 }
+
 export const Events = withNotificationContext(EventsClass);

--- a/src/pages/events/list/Events.tsx
+++ b/src/pages/events/list/Events.tsx
@@ -77,7 +77,7 @@ class EventsClass extends FallibleReactComponent<CalendarPropsType, CalendarStat
                             key: 'calendar',
                             content: (
                                 this.state.events
-                                    ? <CalendarRedo events={this.state.events} days={5}/>
+                                    ? <CalendarRedo events={this.state.events} days={7}/>
                                     : loadOrError
                             ),
                             name: 'Calendar',

--- a/src/pages/events/view/Event.tsx
+++ b/src/pages/events/view/Event.tsx
@@ -107,7 +107,11 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
 
     shouldComponentUpdate(nextProps: Readonly<SimpleEventProps>, nextState: Readonly<EventStateType>, nextContext: any): boolean {
         if (nextProps.id !== this.props.id) return true;
-        return super.shouldComponentUpdate?.(nextProps, nextState, nextContext) ?? true;
+        if (super.shouldComponentUpdate) {
+            return super.shouldComponentUpdate(nextProps, nextState, nextContext) ?? true;
+        }
+
+        return true;
     }
 
     /**

--- a/src/pages/events/view/Event.tsx
+++ b/src/pages/events/view/Event.tsx
@@ -1,18 +1,18 @@
-import React, { FunctionComponent } from 'react';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import React, {FunctionComponent} from 'react';
+import {Link, RouteComponentProps, withRouter} from 'react-router-dom';
 import Loader from 'react-loader-spinner';
 
 import moment from 'moment';
 import ReactTimeAgo from 'react-time-ago';
-import { faFileCode, faNetworkWired, faSkullCrossbones, faTimes } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { withNotificationContext } from '../../../components/WithNotificationContext';
-import { NotificationContextType } from '../../../context/NotificationContext';
-import { FileList } from '../../../components/atoms/file-bar/FileBar';
-import { CommentList } from '../../../components/components/comment-list/CommentList';
-import { EditableProperty } from '../../../components/components/editable-property/EditableProperty';
-import { Theme } from '../../../theme/Theme';
-import { KeyValueOption, Select } from '../../../components/atoms/select/Select';
+import {faFileCode, faNetworkWired, faSkullCrossbones, faTimes} from '@fortawesome/free-solid-svg-icons';
+import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
+import {withNotificationContext} from '../../../components/WithNotificationContext';
+import {NotificationContextType} from '../../../context/NotificationContext';
+import {FileList} from '../../../components/atoms/file-bar/FileBar';
+import {CommentList} from '../../../components/components/comment-list/CommentList';
+import {EditableProperty} from '../../../components/components/editable-property/EditableProperty';
+import {Theme} from '../../../theme/Theme';
+import {KeyValueOption, Select} from '../../../components/atoms/select/Select';
 import {
     API,
     CommentResponse,
@@ -27,14 +27,15 @@ import {
     User,
     VenueResponse,
 } from '../../../utilities/APIGen';
-import { Button } from '../../../components/atoms/button/Button';
-import { GlobalContext } from '../../../context/GlobalContext';
+import {Button} from '../../../components/atoms/button/Button';
+import {GlobalContext} from '../../../context/GlobalContext';
 import './Event.scss';
 import {
     FallibleReactComponent,
     FallibleReactStateType
 } from "../../../components/components/error-screen/FallibleReactComponent";
-import { UIUtilities } from "../../../utilities/UIUtilities";
+import {UIUtilities} from "../../../utilities/UIUtilities";
+import {RemovableVenueChip} from "../../../components/atoms/venue-chip/VenueChip";
 
 export type SimpleEventProps = {
     notificationContext?: NotificationContextType,
@@ -154,20 +155,6 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
 
             this.failedLoad(`Could not load comments: ${err.message}`);
         });
-        // Axios.get(
-        //     urljoin(
-        //         Config.BASE_GATEWAY_URI,
-        //         'events',
-        //         encodeURIComponent(this.props.match.params.id),
-        //         'comments',
-        //     ),
-        // ).then((data) => {
-        //     // TODO: add schema validation for data returned by the server
-        //     this.setState((oldState) => ({
-        //         ...oldState,
-        //         comments: data.data.result,
-        //     }));
-        // })
 
         API.events.id.files.get(this.props.id).then((data) => {
             if (data.status === 'PARTIAL') UIUtilities.tryShowPartialWarning(this);
@@ -182,25 +169,6 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
 
             this.failedLoad(`Could not load event: ${err.message}`);
         });
-        // Axios.get(
-        //     urljoin(
-        //         Config.BASE_GATEWAY_URI,
-        //         'events',
-        //         encodeURIComponent(this.props.match.params.id),
-        //         'files',
-        //     ),
-        // ).then((data) => {
-        //     // TODO: add schema validation for data returned by the server
-        //     this.setState((oldState) => ({
-        //         ...oldState,
-        //         files: data.data.result,
-        //     }));
-        // }).catch((err: Error) => {
-        //     console.error('Failed to load event data');
-        //     console.error(err);
-        //
-        //     this.failedLoad(`Could not load event: ${err.message}`);
-        // });
 
         API.venues.get().then((data) => {
             if (data.status === 'PARTIAL') UIUtilities.tryShowPartialWarning(this);
@@ -215,21 +183,6 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
 
             this.failedLoad(`Could not load list of venues: ${err.message}`);
         });
-        // Axios.get(urljoin(
-        //     Config.BASE_GATEWAY_URI,
-        //     'venues',
-        // )).then((data) => {
-        //     // TODO: add schema validation for data returned by the server
-        //     this.setState((oldState) => ({
-        //         ...oldState,
-        //         venues: data.data.result,
-        //     }));
-        // }).catch((err: Error) => {
-        //     console.error('Failed to load event data');
-        //     console.error(err);
-        //
-        //     this.failedLoad(`Could not load list of venues: ${err.message}`);
-        // });
 
         API.ents.get().then((data) => {
             if (data.status === 'PARTIAL') UIUtilities.tryShowPartialWarning(this);
@@ -244,21 +197,6 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
 
             this.failedLoad(`Could not load list of ents states: ${err.message}`);
         });
-        // Axios.get(urljoin(
-        //     Config.BASE_GATEWAY_URI,
-        //     'ents',
-        // )).then((data) => {
-        //     // TODO: add schema validation for data returned by the server
-        //     this.setState((oldState) => ({
-        //         ...oldState,
-        //         entsStates: data.data.result,
-        //     }));
-        // }).catch((err: Error) => {
-        //     console.error('Failed to load event data');
-        //     console.error(err);
-        //
-        //     this.failedLoad(`Could not load list of ents states: ${err.message}`);
-        // });
 
         API.states.get().then((data) => {
             if (data.status === 'PARTIAL') UIUtilities.tryShowPartialWarning(this);
@@ -273,21 +211,6 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
 
             this.failedLoad(`Could not load list of ents states: ${err.message}`);
         });
-        // Axios.get(urljoin(
-        //     Config.BASE_GATEWAY_URI,
-        //     'states',
-        // )).then((data) => {
-        //     // TODO: add schema validation for data returned by the server
-        //     this.setState((oldState) => ({
-        //         ...oldState,
-        //         buildingStates: data.data.result,
-        //     }));
-        // }).catch((err: Error) => {
-        //     console.error('Failed to load event data');
-        //     console.error(err);
-        //
-        //     this.failedLoad(`Could not load list of ents states: ${err.message}`);
-        // });
 
         API.events.id.get(this.props.id).then((data) => {
             if (data.status === 'PARTIAL') UIUtilities.tryShowPartialWarning(this);
@@ -360,7 +283,7 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
         // if (Object.prototype.hasOwnProperty.call(filtered, 'venue')) {
         //     filtered.venue = this.state.venues?.find((e) => e.id === changeProps.venue);
         // }
-        const updatedEvent: EventResponse = { ...this.state.event, ...filtered };
+        const updatedEvent: EventResponse = {...this.state.event, ...filtered};
 
         API.events.id.patch(this.state.event.id, changeProps).then(() => {
             // The response only contains an ID so we need to spread the updated parameters on top of the existing ones
@@ -518,11 +441,11 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
         <div key={`signup.${user.id}.${signupID}`} className="signup">
             <Link className="user" to={`/users/${user.id}`}>
                 <div className="profile">
-                    <img alt={`Profile for ${user.name}`} src={user.profile ?? '/default-icon.png'} />
+                    <img alt={`Profile for ${user.name}`} src={user.profile ?? '/default-icon.png'}/>
                 </div>
                 <div className="name">{user.name}</div>
             </Link>
-            <div className="spacer" />
+            <div className="spacer"/>
             {/* TODO: FIGURE OUT PERMISSIONS SO THIS IS NOT AVAILABLE TO EVERYONE */}
             <div className="remove">
                 <FontAwesomeIcon
@@ -632,7 +555,32 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
         ).flat();
     }
 
+    private editVenues = (action: 'add' | 'remove', ids: string[]) => {
+        if (this.state.event === undefined) return;
+
+        const edit: any = {};
+        if (action === 'add') edit.addVenues = ids;
+        else edit.removeVenues = ids;
+
+        const replacement = {...this.state.event};
+        if (action === 'remove') replacement.venues = replacement.venues.filter((e) => !ids.includes(e.id));
+        else replacement.venues = [...replacement.venues, ...(this.state.venues?.filter((e) => ids.includes(e.id)) ?? [])];
+
+        API.events.id.patch(this.state.event.id, edit).then(() => {
+            this.setState((oldState) => ({
+                ...oldState,
+                event: replacement,
+            }));
+
+            if (this.props.onChange) this.props.onChange(replacement);
+        }).catch((err) => {
+            console.error(err);
+            this.failedLoad('Could not save the event!');
+        });
+    }
+
     realRender() {
+        const venueIDs = this.state.event?.venues.map((e) => e.id) ?? [];
         return this.state.event ? (
             <div className="event-view loaded">
                 <div className="real">
@@ -646,13 +594,13 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
                             }),
                         }}
                     >
-                        <h1 style={{ display: 'inline-block' }}>{this.state.event.name}</h1>
+                        <h1 style={{display: 'inline-block'}}>{this.state.event.name}</h1>
                     </EditableProperty>
                     <div className="properties-bar">
                         <div className="property creation">
                             <span className="label">Created</span>
                             <span className="value">
-                                <ReactTimeAgo date={this.state.event.start * 1000} />
+                                <ReactTimeAgo date={this.state.event.start * 1000}/>
                             </span>
                         </div>
                         <div className="property updates">
@@ -665,7 +613,7 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
                     {/* TODO: add file loading */}
                     {
                         this.state.files
-                            ? (<FileList files={this.state.files} />)
+                            ? (<FileList files={this.state.files}/>)
                             : undefined
                     }
                     <Button
@@ -691,17 +639,22 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
                 <div className="rightbar-real">
                     <div className="entry">
                         <div className="title">Venue</div>
-                        {/*TODO: rebuild venue selector for checkboxes*/}
-                        {/*{this.generateEditableProperty(*/}
-                        {/*    this.state.venues?.map((e: VenueResponse) => ({*/}
-                        {/*        text: e.name,*/}
-                        {/*        value: e.id,*/}
-                        {/*        additional: e,*/}
-                        {/*    })),*/}
-                        {/*    'Venue',*/}
-                        {/*    this.state.event.venue?.name,*/}
-                        {/*    'venue',*/}
-                        {/*)}*/}
+                        <EditableProperty
+                            name="Add New Venue"
+                            config={{
+                                type: 'select',
+                                options: (this.state.venues ?? [])
+                                    .filter((e) => !venueIDs.includes(e.id))
+                                    .map((e) => ({text: e.name, value: e.id})),
+                                onChange: (result) => typeof (result) === 'string' ? this.editVenues('add', [result])
+                                    : this.editVenues('add', [result.value]),
+                            }}
+                        >
+                            {(this.state.event.venues ?? []).map((e) =>
+                                <RemovableVenueChip venue={e} key={e.id}
+                                                    onRemove={() => this.editVenues('remove', [e.id])}/>
+                            )}
+                        </EditableProperty>
                     </div>
                     <div className="entry">
                         <div className="title">Reservation</div>
@@ -782,13 +735,13 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
                                     {moment.unix(this.state.event.start).format('dddd Do MMMM (YYYY), HH:mm')}
                                 </EditableProperty>
                             </div>
-                            <div className="bar" />
+                            <div className="bar"/>
                             <div className="duration">
                                 {moment.duration(
                                     moment.unix(this.state.event.start).diff(moment.unix(this.state.event.end)),
                                 ).humanize()}
                             </div>
-                            <div className="bar" />
+                            <div className="bar"/>
                             <div className="label">
                                 Booking End
                             </div>
@@ -838,7 +791,7 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
                         />
                     </div>
                 </div>
-                <div className="rightbar-spacer" />
+                <div className="rightbar-spacer"/>
             </div>
         ) : (
             <div className="event-view loading-pane">
@@ -854,7 +807,7 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
 
 }
 
-const RouteredEvent: FunctionComponent<EventPropsType> = ({ match, notificationContext, onChange }) => {
+const RouteredEvent: FunctionComponent<EventPropsType> = ({match, notificationContext, onChange}) => {
     const copy: SimpleEventProps = {
         id: match.params.id,
         notificationContext,

--- a/src/pages/events/view/Event.tsx
+++ b/src/pages/events/view/Event.tsx
@@ -704,6 +704,19 @@ class Event extends FallibleReactComponent<SimpleEventProps, EventStateType> {
                         {/*)}*/}
                     </div>
                     <div className="entry">
+                        <div className="title">Reservation</div>
+                        <EditableProperty
+                            name="Reserved"
+                            config={{
+                                type: 'checkbox',
+                                value: this.state.event.reserved ?? false,
+                                onChange: this.changeProperty('reserved'),
+                            }}
+                        >
+                            {this.state.event.reserved ? 'Space reserved' : 'Unreserved'}
+                        </EditableProperty>
+                    </div>
+                    <div className="entry">
                         <div className="title">Projected Attendance</div>
                         <EditableProperty
                             name="attendance"

--- a/src/pages/venues/view/Venue.tsx
+++ b/src/pages/venues/view/Venue.tsx
@@ -1,0 +1,105 @@
+import {API, EventResponse, VenueResponse, VenueUpdate} from "../../../utilities/APIGen";
+import React from "react";
+import {failEarlyStateSet} from "../../../utilities/AccessUtilities";
+import {UIUtilities} from "../../../utilities/UIUtilities";
+import {NotificationPropsType} from "../../../context/NotificationContext";
+import {faSkullCrossbones} from "@fortawesome/free-solid-svg-icons";
+import {Theme} from "../../../theme/Theme";
+import {EventOrCommentRelatedView} from "../../../components/components/event-related-view/EventOrCommentRelatedView";
+import {loadAPIData} from "../../../utilities/DataUtilities";
+import {
+    FallibleReactComponent,
+    FallibleReactStateType
+} from "../../../components/components/error-screen/FallibleReactComponent";
+import {withNotificationContext} from "../../../components/WithNotificationContext";
+
+export type ViewVenueProps = {
+    venue: VenueResponse;
+    events?: EventResponse[],
+} & NotificationPropsType;
+
+type State = {
+    venue: VenueResponse,
+    events: EventResponse[],
+} & FallibleReactStateType
+
+
+class VenueClass extends FallibleReactComponent<ViewVenueProps, State> {
+
+    static displayName = 'Venue';
+
+    constructor(props: ViewVenueProps) {
+        super(props);
+        this.state = {venue: props.venue, events: props.events ?? []};
+    }
+
+    private patch = (update: VenueUpdate) => {
+        API.venues.id.patch(this.props.venue.id, update).then(() => {
+            // To fix some typing
+            if (!this.state.venue) return;
+
+            const newVenue: VenueResponse = {
+                ...this.state.venue,
+                ...update,
+            };
+
+            failEarlyStateSet(
+                this.state,
+                this.setState.bind(this),
+                'venue',
+            )(newVenue);
+        }).catch((err) => {
+            console.error(err);
+            UIUtilities.tryShowNotification(
+                this.props.notificationContext,
+                'Failed to update venue',
+                `There was an error submitting the update request: ${err.message}`,
+                faSkullCrossbones,
+                Theme.FAILURE,
+            )
+        });
+    }
+
+    componentDidMount() {
+        if (this.props.events === undefined) {
+            loadAPIData<State>([{
+                    call: API.venues.id.events.get,
+                    stateName: 'events',
+                    params: [this.props.venue.id],
+                }],
+                this.setState.bind(this),
+                () => UIUtilities.tryShowPartialWarning(this),
+            );
+        }
+    }
+
+    realRender() {
+        return (
+            <EventOrCommentRelatedView
+                obj={this.state.venue}
+                patch={(changes: VenueUpdate) => {
+                    this.patch(changes);
+                }}
+                configOverrides={[
+                    {
+                        property: 'color',
+                        type: 'color',
+                    },
+                ]}
+                excluded={[
+                    'id',
+                    'user',
+                    'date',
+                ]}
+                events={this.state.events}
+                delete={{
+                    redirect: '/venues',
+                    onDelete: () => UIUtilities.deleteWith409Support(() => API.venues.id.delete(this.props.venue.id)),
+                }}
+            />
+        );
+    }
+}
+
+const Venue = withNotificationContext(VenueClass);
+export default Venue;

--- a/src/pages/venues/view/ViewVenue.tsx
+++ b/src/pages/venues/view/ViewVenue.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { API, EventResponse, VenueResponse, VenueUpdate } from '../../../utilities/APIGen';
-import { failEarlyStateSet } from '../../../utilities/AccessUtilities';
-import { EventOrCommentRelatedView } from '../../../components/components/event-related-view/EventOrCommentRelatedView';
-import { loadAPIData } from '../../../utilities/DataUtilities';
+import {RouteComponentProps, withRouter} from 'react-router-dom';
+import {API, EventResponse, VenueResponse} from '../../../utilities/APIGen';
+import {loadAPIData} from '../../../utilities/DataUtilities';
 import {
     FallibleReactComponent,
     FallibleReactStateType,
@@ -11,6 +9,7 @@ import {
 import {UIUtilities} from "../../../utilities/UIUtilities";
 import {NotificationPropsType} from "../../../context/NotificationContext";
 import {withNotificationContext} from "../../../components/WithNotificationContext";
+import Venue from "./Venue";
 
 export type ViewVenuePropsType = {} & RouteComponentProps<{
     id: string,
@@ -49,55 +48,9 @@ class ViewVenueClass extends FallibleReactComponent<ViewVenuePropsType, ViewVenu
         );
     }
 
-    //
-    private patch = (update: VenueUpdate) => {
-        console.log(update);
-        API.venues.id.patch(this.props.match.params.id, update).then(() => {
-            // To fix some typing
-            if (!this.state.venue) return;
-
-            const newVenue: VenueResponse = {
-                ...this.state.venue,
-                ...update,
-            };
-
-            failEarlyStateSet(
-                this.state,
-                this.setState.bind(this),
-                'venue',
-            )(newVenue);
-        }).catch((err) => {
-            console.error(err);
-            // TODO: error handling w/ notifs
-        });
-    }
-
     realRender() {
         if (this.state.venue) {
-            return (
-                <EventOrCommentRelatedView
-                    obj={this.state.venue}
-                    patch={(changes: VenueUpdate) => {
-                        this.patch(changes);
-                    }}
-                    configOverrides={[
-                        {
-                            property: 'color',
-                            type: 'color',
-                        },
-                    ]}
-                    excluded={[
-                        'id',
-                        'user',
-                        'date',
-                    ]}
-                    events={this.state.events}
-                    delete={{
-                        redirect: '/venues',
-                        onDelete: () => UIUtilities.deleteWith409Support(()=> API.venues.id.delete(this.props.match.params.id)),
-                    }}
-                />
-            );
+            return (<Venue venue={this.state.venue} events={this.state.events}/>);
         }
         return null;
     }

--- a/src/pages/workflows/ops-planning/OpsPlanning.module.scss
+++ b/src/pages/workflows/ops-planning/OpsPlanning.module.scss
@@ -1,0 +1,54 @@
+.opsPlanning {
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+
+  .sidebar {
+    height: 100%;
+    overflow-y: auto;
+    flex-basis: 15%;
+    flex-shrink: 0;
+    flex-grow: 0;
+    background: #fbfbfb;
+    border-right: 1px solid gainsboro;
+    max-height: 100vh;
+
+    .card {
+      border-bottom: 1px solid gainsboro;
+
+      .inner {
+        padding: 15px;
+
+        > strong {
+          display: block;
+          font-size: 1.3em;
+          padding-bottom: 5px;
+        }
+
+        .venues {
+          display: block;
+          margin-top: 5px;
+        }
+      }
+
+      .lower {
+        display: flex;
+        flex-direction: row;
+
+        > div {
+          padding: 5px;
+          text-align: center;
+          flex-basis: 50%;
+          color: white;
+          background: red;
+        }
+      }
+    }
+  }
+
+  .content {
+    height: 100%;
+    overflow-y: auto;
+    flex-grow: 1;
+  }
+}

--- a/src/pages/workflows/ops-planning/OpsPlanning.tsx
+++ b/src/pages/workflows/ops-planning/OpsPlanning.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 
 import styles from './OpsPlanning.module.scss';
-import { BasicEvent } from "../../events/view/Event";
-import { API, EventResponse, StateResponse } from "../../../utilities/APIGen";
-import { UIUtilities } from "../../../utilities/UIUtilities";
-import { NotificationPropsType } from "../../../context/NotificationContext";
-import { faSkullCrossbones } from "@fortawesome/free-solid-svg-icons";
-import { Theme } from "../../../theme/Theme";
+import {BasicEvent} from "../../events/view/Event";
+import {API, EventResponse, StateResponse} from "../../../utilities/APIGen";
+import {UIUtilities} from "../../../utilities/UIUtilities";
+import {NotificationPropsType} from "../../../context/NotificationContext";
+import {faSkullCrossbones} from "@fortawesome/free-solid-svg-icons";
+import {Theme} from "../../../theme/Theme";
 
 type OpsPlanningProps = {} & NotificationPropsType;
 
 type OpsPlanningState = {
     events?: EventResponse[],
-    states?: StateResponse[],
+    states?: string[],
     selected?: string,
 };
 
@@ -61,7 +61,7 @@ class OpsPlanningClass extends React.Component<OpsPlanningProps, OpsPlanningStat
             console.log(data.result);
             this.setState((oldState) => ({
                 ...oldState,
-                states: data.result,
+                states: data.result as string[],
             }));
         }).catch((err: Error) => {
             console.error('Failed to load states data');
@@ -75,7 +75,7 @@ class OpsPlanningClass extends React.Component<OpsPlanningProps, OpsPlanningStat
         console.log('filtering events', updated, this.state.states);
         if (this.state.states === undefined) return;
         if (updated.state === undefined) return;
-        if (!this.state.states.map((e) => e.id).includes(updated.state.id)) {
+        if (!this.state.states.map((e) => e).includes(updated.state.id)) {
             this.setState((e) => {
                 if (e === undefined) return e;
                 return {
@@ -105,23 +105,26 @@ class OpsPlanningClass extends React.Component<OpsPlanningProps, OpsPlanningStat
     private makeCard(event: EventResponse) {
         return (
             <div className={styles.card} onClick={() => {
-                this.setState((s) => ({ ...s, selected: event.id }))
+                this.setState((s) => ({...s, selected: event.id}))
             }} key={`evt-card-${event.id}`}>
                 <div className={styles.inner}>
                     <strong>{event.name}</strong>
                     <div>
                         <strong>Start </strong><span>{event.start}</span>
-                        <br />
+                        <br/>
                         <strong>End </strong><span>{event.end}</span>
-                        <br />
+                        <br/>
                         <span className={styles.venues}>{event.venues.map((e) => e.name).join(', ')}</span>
+                        <br/>
+                        {!event.reserved ? ['Space is not reserved', <br/>] : ''}
+                        {this.state.states !== undefined && event.state !== undefined && this.state.states.includes(event.state.id) ? 'In review' : ''}
                     </div>
                 </div>
                 <div className={styles.lower}>
                     <div
-                        style={{ backgroundColor: event.state?.color ?? 'black' }}>{event.state?.name ?? 'Not Assigned'}</div>
+                        style={{backgroundColor: event.state?.color ?? 'black'}}>{event.state?.name ?? 'Not Assigned'}</div>
                     <div
-                        style={{ backgroundColor: event.ents?.color ?? 'black' }}>{event.ents?.name ?? 'Not Assigned'}</div>
+                        style={{backgroundColor: event.ents?.color ?? 'black'}}>{event.ents?.name ?? 'Not Assigned'}</div>
                 </div>
             </div>
         )

--- a/src/pages/workflows/ops-planning/OpsPlanning.tsx
+++ b/src/pages/workflows/ops-planning/OpsPlanning.tsx
@@ -1,10 +1,30 @@
 import React from "react";
 
-type OpsPlanningProps = {};
+import styles from './OpsPlanning.module.scss';
+import { BasicEvent } from "../../events/view/Event";
+import { API, EventResponse, StateResponse } from "../../../utilities/APIGen";
+import { UIUtilities } from "../../../utilities/UIUtilities";
+import { NotificationPropsType } from "../../../context/NotificationContext";
+import { faSkullCrossbones } from "@fortawesome/free-solid-svg-icons";
+import { Theme } from "../../../theme/Theme";
 
-type OpsPlanningState = {};
+type OpsPlanningProps = {} & NotificationPropsType;
+
+type OpsPlanningState = {
+    events?: EventResponse[],
+    states?: StateResponse[],
+    selected?: string,
+};
 
 class OpsPlanningClass extends React.Component<OpsPlanningProps, OpsPlanningState> {
+    constructor(props: OpsPlanningProps, context: any) {
+        super(props, context);
+
+        this.makeCard = this.makeCard.bind(this);
+        this.filterEvents = this.filterEvents.bind(this);
+        this.state = {};
+    }
+
     /**
      * Summary: this page is a single workflow for an ops planning meeting
      *  - Show all events that are pending approval (how?)
@@ -12,14 +32,118 @@ class OpsPlanningClass extends React.Component<OpsPlanningProps, OpsPlanningStat
      *  - Show any clashes
      *
      *  TODO:
-     *    * Users need to be able to configure which state IDs match review states
-     *    * New endpoint for fetching review events which uses these states
+     *    * [x] Users need to be able to configure which state IDs match review states
+     *    * [x ]New endpoint for fetching review events which uses these states
      *    * How should gateway persist data? MongoDB? Should this be on a microservice?
      *      * Needs some kind of shared store and we shouldn't add new modules, so mongo will have to do...
      *      * Can link this into logging as well
      *      * Gateway already uses mongo for sessions - need a new collection and maybe move collection
      *    * What to do when states are deleted?
      */
+
+
+    componentDidMount() {
+        API.events.review.get().then((data) => {
+            if (data.status === 'PARTIAL') UIUtilities.tryShowPartialWarning(this);
+
+            this.setState((oldState) => ({
+                ...oldState,
+                events: data.result,
+            }));
+        }).catch((err: Error) => {
+            console.error('Failed to load events data');
+            console.error(err);
+
+            this.failedLoad(`Could not load event list list: ${err.message}`);
+        });
+        API.states.review.get().then((data) => {
+            if (data.status === 'PARTIAL') UIUtilities.tryShowPartialWarning(this);
+            console.log(data.result);
+            this.setState((oldState) => ({
+                ...oldState,
+                states: data.result,
+            }));
+        }).catch((err: Error) => {
+            console.error('Failed to load states data');
+            console.error(err);
+
+            this.failedLoad(`Could not load states list list: ${err.message}`);
+        });
+    }
+
+    private filterEvents = (updated: EventResponse) => {
+        console.log('filtering events', updated, this.state.states);
+        if (this.state.states === undefined) return;
+        if (updated.state === undefined) return;
+        if (!this.state.states.map((e) => e.id).includes(updated.state.id)) {
+            this.setState((e) => {
+                if (e === undefined) return e;
+                return {
+                    ...e,
+                    events: (e.events ?? []).filter((v) => v.id !== updated.id),
+                }
+            });
+        }
+    }
+
+    private failedLoad = (reason: string) => {
+        if (this.props.notificationContext) {
+            try {
+                this.props.notificationContext.showNotification(
+                    'Failed to Load',
+                    `There was an error: ${reason}`,
+                    faSkullCrossbones,
+                    Theme.FAILURE,
+                );
+                console.log('Notification shown');
+            } catch (e) {
+                console.error('Notification system failed to send');
+            }
+        }
+    }
+
+    private makeCard(event: EventResponse) {
+        return (
+            <div className={styles.card} onClick={() => {
+                this.setState((s) => ({ ...s, selected: event.id }))
+            }} key={`evt-card-${event.id}`}>
+                <div className={styles.inner}>
+                    <strong>{event.name}</strong>
+                    <div>
+                        <strong>Start </strong><span>{event.start}</span>
+                        <br />
+                        <strong>End </strong><span>{event.end}</span>
+                        <br />
+                        <span className={styles.venues}>{event.venues.map((e) => e.name).join(', ')}</span>
+                    </div>
+                </div>
+                <div className={styles.lower}>
+                    <div
+                        style={{ backgroundColor: event.state?.color ?? 'black' }}>{event.state?.name ?? 'Not Assigned'}</div>
+                    <div
+                        style={{ backgroundColor: event.ents?.color ?? 'black' }}>{event.ents?.name ?? 'Not Assigned'}</div>
+                </div>
+            </div>
+        )
+    }
+
+    render() {
+        return (
+            <div className={styles.opsPlanning}>
+                <div className={styles.sidebar}>
+                    {(this.state.events ?? []).map(this.makeCard)}
+                </div>
+                <div className={styles.content}>
+                    {this.state.selected ? (
+                        <BasicEvent
+                            key={this.state.selected}
+                            id={this.state.selected}
+                            onChange={this.filterEvents}
+                        />) : undefined}
+                </div>
+            </div>
+        );
+    }
 }
 
 export const OpsPlanning = OpsPlanningClass;

--- a/src/pages/workflows/ops-planning/OpsPlanning.tsx
+++ b/src/pages/workflows/ops-planning/OpsPlanning.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import styles from './OpsPlanning.module.scss';
 import {BasicEvent} from "../../events/view/Event";
-import {API, EventResponse, StateResponse} from "../../../utilities/APIGen";
+import {API, EventResponse} from "../../../utilities/APIGen";
 import {UIUtilities} from "../../../utilities/UIUtilities";
 import {NotificationPropsType} from "../../../context/NotificationContext";
 import {faSkullCrossbones} from "@fortawesome/free-solid-svg-icons";
@@ -24,23 +24,6 @@ class OpsPlanningClass extends React.Component<OpsPlanningProps, OpsPlanningStat
         this.filterEvents = this.filterEvents.bind(this);
         this.state = {};
     }
-
-    /**
-     * Summary: this page is a single workflow for an ops planning meeting
-     *  - Show all events that are pending approval (how?)
-     *  - For each event show events in other venues at the same time
-     *  - Show any clashes
-     *
-     *  TODO:
-     *    * [x] Users need to be able to configure which state IDs match review states
-     *    * [x ]New endpoint for fetching review events which uses these states
-     *    * How should gateway persist data? MongoDB? Should this be on a microservice?
-     *      * Needs some kind of shared store and we shouldn't add new modules, so mongo will have to do...
-     *      * Can link this into logging as well
-     *      * Gateway already uses mongo for sessions - need a new collection and maybe move collection
-     *    * What to do when states are deleted?
-     */
-
 
     componentDidMount() {
         API.events.review.get().then((data) => {

--- a/src/pages/workflows/ops-planning/OpsPlanning.tsx
+++ b/src/pages/workflows/ops-planning/OpsPlanning.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+type OpsPlanningProps = {};
+
+type OpsPlanningState = {};
+
+class OpsPlanningClass extends React.Component<OpsPlanningProps, OpsPlanningState> {
+    /**
+     * Summary: this page is a single workflow for an ops planning meeting
+     *  - Show all events that are pending approval (how?)
+     *  - For each event show events in other venues at the same time
+     *  - Show any clashes
+     *
+     *  TODO:
+     *    * Users need to be able to configure which state IDs match review states
+     *    * New endpoint for fetching review events which uses these states
+     *    * How should gateway persist data? MongoDB? Should this be on a microservice?
+     *      * Needs some kind of shared store and we shouldn't add new modules, so mongo will have to do...
+     *      * Can link this into logging as well
+     *      * Gateway already uses mongo for sessions - need a new collection and maybe move collection
+     *    * What to do when states are deleted?
+     */
+}
+
+export const OpsPlanning = OpsPlanningClass;

--- a/src/utilities/APIGen.ts
+++ b/src/utilities/APIGen.ts
@@ -620,6 +620,12 @@ export const GetVenuesIdEventsAPIResponseZod = SuccessfulAPIResponseZod.extend({
     result: z.array(EventResponseZod),
 });
 export type GetVenuesIdEventsAPIResponse = z.infer<typeof GetVenuesIdEventsAPIResponseZod>;
+
+export const GetReviewStatesAPIResponseZod = SuccessfulAPIResponseZod.extend({
+    result: IDOnlyResponseZod,
+});
+export type GetReviewStatesAPIResponse = z.infer<typeof GetReviewStatesAPIResponseZod>;
+
 //=============
 export type APIType = {
     events: {
@@ -761,7 +767,7 @@ export type APIType = {
         },
         review: {
             get: ()
-                => Promise<GetStatesAPIResponse>,
+                => Promise<GetReviewStatesAPIResponse>,
         },
     },
     topics: {
@@ -1440,13 +1446,13 @@ export const API: APIType = {
         },
         review: {
             get:
-                bind<GetStatesAPIResponse>(
+                bind<GetReviewStatesAPIResponse>(
                     (
                         uri: string,
-                    ) => getRequest<GetStatesAPIResponse>(
+                    ) => getRequest<GetReviewStatesAPIResponse>(
                         uri,
                         {},
-                        GetStatesAPIResponseZod,
+                        GetReviewStatesAPIResponseZod,
                     ),
                     '/states/review',
                     'Retrieves all review states',

--- a/src/utilities/APIGen.ts
+++ b/src/utilities/APIGen.ts
@@ -682,6 +682,10 @@ export type APIType = {
                         => Promise<void>
                 }
             }
+        },
+        review: {
+            get: ()
+                => Promise<GetEventAPIResponse>,
         }
     },
     files: {
@@ -754,7 +758,11 @@ export type APIType = {
                 get: (id: string)
                     => Promise<GetStatesIdEventsAPIResponse>
             }
-        }
+        },
+        review: {
+            get: ()
+                => Promise<GetStatesAPIResponse>,
+        },
     },
     topics: {
         get: ()
@@ -1083,6 +1091,19 @@ export const API: APIType = {
                         )
                 }
             }
+        },
+        review: {
+            get: bind<GetEventAPIResponse>(
+                (
+                    uri: string,
+                ) => getRequest<GetEventAPIResponse>(
+                    uri,
+                    {},
+                    GetEventAPIResponseZod,
+                ),
+                '/events/review',
+                'Retrieves the event',
+            ),
         }
     },
     files: {
@@ -1416,6 +1437,20 @@ export const API: APIType = {
                         'Retrieves all events with this state',
                     )
             }
+        },
+        review: {
+            get:
+                bind<GetStatesAPIResponse>(
+                    (
+                        uri: string,
+                    ) => getRequest<GetStatesAPIResponse>(
+                        uri,
+                        {},
+                        GetStatesAPIResponseZod,
+                    ),
+                    '/states/review',
+                    'Retrieves all review states',
+                )
         }
     },
     topics: {

--- a/src/utilities/APIGen.ts
+++ b/src/utilities/APIGen.ts
@@ -320,6 +320,7 @@ export const EventUpdateZod = z.object({
     state: z.string().optional(),
     attendance: z.number().optional(),
     color: z.string().optional(),
+    reserved: z.boolean().optional(),
 });
 export type EventUpdate = z.infer<typeof EventUpdateZod>;
 export const TopicUpdateZod = z.object({

--- a/src/utilities/Routes.ts
+++ b/src/utilities/Routes.ts
@@ -1,0 +1,39 @@
+type GenericRoute<T extends Function> = string & {
+    make: T;
+    string: string,
+};
+type Route = GenericRoute<((...values: string[]) => string)>;
+type RouteOne = GenericRoute<((a: string) => string)>;
+type RouteTwo = GenericRoute<((a: string, b: string) => string)>;
+
+function make<T extends GenericRoute<any>>(router: string): T {
+    const parts = router.split('/');
+    const elements = parts.filter((e) => e.startsWith(':')).length;
+    if (elements > 2) throw new Error('cannot parse');
+
+    let makeMake = (args: string[]) => {
+        let activeIndex = 0;
+        let result = [];
+        for (let i = 0; i < parts.length; i++) {
+            if (parts[i].startsWith(':')) {
+                result.push(args[activeIndex]);
+                activeIndex++;
+            } else {
+                result.push(parts[i]);
+            }
+        }
+        return result.join('/');
+    }
+
+    // TODO: better types? 'as any' is baaaad
+    if (elements === 0) return Object.assign(router, {make: () => router, string: router}) as any;
+    if (elements === 1) return Object.assign(router, {make: (a: string) => makeMake([a]), string: router}) as any;
+    if (elements === 2) return Object.assign(router, {
+        make: (a: string, b: string) => makeMake([a, b]),
+        string: router
+    }) as any;
+    throw new Error('failed');
+}
+
+export const OPS_PLANNING = make<Route>('/workflow/ops');
+export const EVENT_VIEW = make<RouteOne>('/events/:id');

--- a/src/utilities/UIUtilities.ts
+++ b/src/utilities/UIUtilities.ts
@@ -139,3 +139,8 @@ export class UIUtilities {
     }
 
 }
+
+
+export function classes(...classes: (string|undefined)[]){
+    return classes.filter((e) => e !== undefined).join(' ');
+}


### PR DESCRIPTION
Across all elements this includes:

## [frontend](https://github.com/ents-crew/uems-frontend-themis)
* Adds ops planning workflow
  * This will list all records that are in the review states or do not have the space reserved. 
* Adds new calendar to the frontend
  * This new calendar models the google calendar layout including record stacking and seems to work pretty well. This will allow you to get a better overview. This needs some additional tweaks to integrate more fully
* Makes frontend more modular for events and venues
  * This allows displaying an already loaded element, not pulling it again from the API. This needs to be rolled out further to other view pages but is working well
* Adds venue chips to the frontend
  * Name describes them, a better way to view the venues on the event view pages and more
* Removes user linking from comments
  * User pages are not important and have been removed from the plans from the time being
* Remedies tab pane sizing on frontend
  * They now fill the page

## [events](https://github.com/ents-crew/uems-event-micro-dionysus)
* Adds support for searching by state set
  * This now allows you to specify an array of states and return events which contain at least one of those states. This is used to back the ops planning workflow to retrieve all events based on their states
* Adding event reservation support
  * This allows events to be submitted but not reserve the space. This is not rolled out fully into the system yet and needs some integration into the frontend and when the admin interface gets built there will be a default option. This will allow it to either act like the old system (anyone can book overlapping events) or like the new system (a booking request reserved the space)
* Integrates an entire new AMQPlib based logging system
  * This is presently integrated with greylog locally but could be linked into any system - there is no official solution here. 
* Adding request ID to logging
  * This allows correlational tracking through all services

## [gateway](https://github.com/ents-crew/uems-gateway)
* Adding configuration to gateway
  * Configuration is backed by mongodb in a new collection.
* Adding review states with associated routes
  * Review states are added into the configuration in the database and there is a general config object through which these values will be pulled. It only has get paths right now, these will be extended further when the admin interface is built
* Adding basic request caching to speed up loading
  * This is not an ideal solution but caching will be a bigger job so needs to be moved over to a new feature branch

## [hub](https://github.com/ents-crew/uems-hub)
* Added requestID to all internal messages
  * Request logging is working well!